### PR TITLE
add multi-tab support to /events/streamData

### DIFF
--- a/src/time.rs
+++ b/src/time.rs
@@ -213,6 +213,18 @@ impl<'r> FromRequest<'r> for OffsetTime {
             .map(Duration::seconds)
         {
             Outcome::Success(OffsetTime(Utc::now() - offset))
+        } else if let Some(offset) = req.uri().query().and_then(|q| {
+            q.segments()
+                .find_map(|(k, v)| {
+                    if k == "_before_offset_time" {
+                        v.parse().ok()
+                    } else {
+                        None
+                    }
+                })
+                .map(Duration::seconds)
+        }) {
+            Outcome::Success(OffsetTime(Utc::now() - offset))
         } else if let Some(offset) = get_offset(req.cookies()) {
             Outcome::Success(OffsetTime(Utc::now() - offset))
         } else {

--- a/templates/game.html
+++ b/templates/game.html
@@ -56,6 +56,24 @@
             }
         }(Date);
 
+        const TrueSource = EventSource;
+    
+        EventSource = function(EventSource) {
+            for (var n of Object.getOwnPropertyNames(EventSource)) {
+                if (n in TrickSource) continue;
+
+                let desc = Object.getOwnPropertyDescriptor(EventSource,n);
+                Object.defineProperty(TrickSource,n,desc);
+            }
+
+            return TrickSource;
+
+            function TrickSource(url, options) {
+                return instantiate(TrueSource, [`${url}?_before_offset_time=${_before_time}`, options]);
+            }
+        }(EventSource);
+
+
         const _before_old_fetch = fetch.bind(window);
         fetch = async function(url, options) {
             if (options === undefined) {


### PR DESCRIPTION
overrides EventSource class to add a url parameter containing the offset time, akin to the fetch header override.
will potentially break if blaseball starts adding url parameters too?

resolves #16 