### PR TITLE
hee hoo tiny snacks

### DIFF
--- a/static/fixes.css
+++ b/static/fixes.css
@@ -1,0 +1,4 @@
+.Shop-Item-Icon {
+    /* older versions of Safari don't support the fit-content value, instead naming it 'intrinsic'. */
+    height: intrinsic; 
+}

--- a/templates/game.html
+++ b/templates/game.html
@@ -14,6 +14,7 @@
     <style>.Main { background-image: none; }</style>
     {% endif %}
     <link href="/_before/nav.css" rel="stylesheet">
+    <link href="/_before/fixes.css" rel="stylesheet">
 </head>
 
 <body>


### PR DESCRIPTION
older versions of safari use intrinsic instead of fit-content, causing sizing issues in the shop's rendering