### PR TITLE
Make spans in ul.event have display type of inline-block even at smal…

### DIFF
--- a/static/before.css
+++ b/static/before.css
@@ -238,6 +238,10 @@ body.theme-light .bigdeal-5 {
   div.season span {
     display: block;
   }
+
+  ul.events span {
+    display: inline-block;
+  }
 }
 
 ._before_credits .Main {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/12659118/148419397-2d68531f-fd07-4f44-80d9-c361b8080e5e.png)
![image](https://user-images.githubusercontent.com/12659118/148422043-3a090cc2-ab36-483e-85f6-1005efc755d5.png)
Display of block for spans at small screensize was pushing pseudo-element for list items below the list. Reapplying the display type of inline-block at small screen sizes fixed this.